### PR TITLE
stops people using message all when their PDA cartridge doesn't allow its use

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -616,7 +616,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 				sort_by_job = !sort_by_job
 
 			if("MessageAll")
-				send_to_all(U)
+				if(cartridge?.spam_enabled)
+					send_to_all(U)
 
 			if("cart")
 				if(cartridge)


### PR DESCRIPTION
## About The Pull Request
hi
another bug found downstream that's also a thing here
you can use funny href to use message all while your pda cartridge doesn't allow it

## Why It's Good For The Game
fixes a thing

## Changelog
:cl:
fix: stops people using message all when their PDA cartridge doesn't allow its use
/:cl:
